### PR TITLE
Deploy: fix Prisma/Neon advisory lock timeout

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -53,6 +53,12 @@ jobs:
 
       - name: Run database migrations
         working-directory: backend
+        # Neon's serverless Postgres can be slow to acquire advisory locks,
+        # which times out `prisma migrate deploy` at the default 10s window.
+        # Disabling the lock is safe here: this workflow runs serially from a
+        # single branch with concurrency=1, so there are no concurrent migrators.
+        env:
+          PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK: "1"
         run: npx prisma migrate deploy --config prisma/prisma.config.ts
 
       - name: Deploy to Container Apps


### PR DESCRIPTION
Workflow-only fix: set PRISMA_SCHEMA_DISABLE_ADVISORY_LOCK=1 for the migrate step. Neon's compute architecture makes advisory lock acquisition slower than Prisma's default 10s. Safe here — workflow is serial (single branch, concurrency=1).