### PR TITLE
Mobile deep-dive: bottom sheets, thumb-zone cleanup, jump-to-live

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "next": "16.1.6",
         "posthog-js": "^1.369.2",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "vaul": "^1.1.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -7360,6 +7361,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/web-vitals": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "next": "16.1.6",
     "posthog-js": "^1.369.2",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/src/app/debate/[id]/page.tsx
+++ b/frontend/src/app/debate/[id]/page.tsx
@@ -72,12 +72,16 @@ function DebateSubheader({
   stages,
   isCompleted,
   isDiscussion,
+  transcriptOpen,
+  onToggleTranscript,
 }: {
   debate: Debate;
   turns: Turn[];
   stages: StageConfig[];
   isCompleted: boolean;
   isDiscussion: boolean;
+  transcriptOpen: boolean;
+  onToggleTranscript: () => void;
 }) {
   const score = useMemo(() => computeMomentum(turns, stages), [turns, stages]);
   const total = score.A + score.B;
@@ -345,6 +349,21 @@ function DebateSubheader({
                 ✓ Done
               </span>
             )}
+            {/* Compact transcript toggle, mobile only (desktop has floating button on left).
+                Shown only once there's at least one turn to jump to. */}
+            {turns.length > 0 && (
+              <button
+                type="button"
+                onClick={onToggleTranscript}
+                aria-label={transcriptOpen ? "Close transcript" : "Open transcript"}
+                aria-expanded={transcriptOpen}
+                className="ml-auto inline-flex h-7 w-7 items-center justify-center rounded-md border border-gray-200 bg-white text-gray-500 transition-colors hover:border-blue-300 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                </svg>
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -384,18 +403,18 @@ function StreamingTurnCard({
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
-      className={`relative rounded-2xl border ${tone.border} ${tone.bg} p-4 shadow-sm sm:p-5`}
+      className={`relative rounded-2xl border ${tone.border} ${tone.bg} p-3 shadow-sm sm:p-5`}
     >
-      <div className="mb-3 flex items-center gap-3">
+      <div className="mb-2.5 flex items-center gap-2.5 sm:mb-3 sm:gap-3">
         {avatarUrl ? (
           <img
             src={avatarUrl}
             alt={speakerName}
-            className={`h-10 w-10 shrink-0 rounded-full object-cover ring-2 ${tone.ring}`}
+            className={`h-9 w-9 shrink-0 rounded-full object-cover ring-2 sm:h-10 sm:w-10 ${tone.ring}`}
           />
         ) : (
           <div
-            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white text-sm font-bold ring-2 ${tone.ring} ${tone.text}`}
+            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white text-sm font-bold ring-2 sm:h-10 sm:w-10 ${tone.ring} ${tone.text}`}
           >
             {speakerName ? speakerName.charAt(0) : "?"}
           </div>
@@ -432,6 +451,8 @@ export default function DebatePage({ params }: DebatePageProps) {
   const [streamingNarrative, setStreamingNarrative] = useState<string>("");
   const [streamingSpeaker, setStreamingSpeaker] = useState<Speaker | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [isAtBottom, setIsAtBottom] = useState(true);
   const bottomRef = useRef<HTMLDivElement>(null);
   const autoStarted = useRef(false);
   const closeStreamRef = useRef<(() => void) | null>(null);
@@ -461,12 +482,35 @@ export default function DebatePage({ params }: DebatePageProps) {
     loadDebate();
   }, [loadDebate]);
 
-  // Auto-scroll to bottom when new turns arrive
+  // Auto-scroll to bottom when new turns arrive (only if user is already at bottom)
   useEffect(() => {
-    if (turns.length > 0 && bottomRef.current) {
+    if (turns.length > 0 && bottomRef.current && isAtBottom) {
       bottomRef.current.scrollIntoView({ behavior: "smooth", block: "end" });
     }
+    // intentionally omitting isAtBottom from deps — we only want to trigger on new turn
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [turns.length]);
+
+  // During streaming, keep the ghost card in view — but only if the user hasn't
+  // scrolled up to look at prior turns (the "sticky-to-bottom unless scrolled" pattern).
+  useEffect(() => {
+    if (streamingNarrative && bottomRef.current && isAtBottom) {
+      bottomRef.current.scrollIntoView({ behavior: "auto", block: "end" });
+    }
+  }, [streamingNarrative, isAtBottom]);
+
+  // Track whether the bottom anchor is visible so we know if the user has
+  // scrolled up. When they scroll back to the bottom, auto-follow resumes.
+  useEffect(() => {
+    const anchor = bottomRef.current;
+    if (!anchor) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsAtBottom(entry.isIntersecting),
+      { threshold: 0, rootMargin: "120px 0px 0px 0px" },
+    );
+    observer.observe(anchor);
+    return () => observer.disconnect();
+  }, [debate?.id]);
 
   // Auto-start: skip the "Begin Debate" step and immediately generate the moderator setup
   useEffect(() => {
@@ -585,6 +629,8 @@ export default function DebatePage({ params }: DebatePageProps) {
         stages={stages}
         isCompleted={!!isCompleted}
         isDiscussion={!!isDiscussion}
+        transcriptOpen={transcriptOpen}
+        onToggleTranscript={() => setTranscriptOpen(!transcriptOpen)}
       />
 
       {/* Main content */}
@@ -601,6 +647,8 @@ export default function DebatePage({ params }: DebatePageProps) {
             stages={stages}
             personaAName={debate.personaA.name}
             personaBName={debate.personaB.name}
+            open={transcriptOpen}
+            onOpenChange={setTranscriptOpen}
           />
         </div>
       ) : (
@@ -717,6 +765,30 @@ export default function DebatePage({ params }: DebatePageProps) {
           {/* Spacer so content doesn't hide behind sticky button */}
           <div className="h-20 sm:h-24" />
 
+          {/* Jump-to-live pill — appears only while streaming and user has scrolled away from bottom. */}
+          <AnimatePresence>
+            {advancing && streamingNarrative && !isAtBottom && (
+              <motion.button
+                key="jump-to-live"
+                type="button"
+                onClick={() =>
+                  bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" })
+                }
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 12 }}
+                style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) + 5.5rem)" }}
+                className="fixed left-1/2 z-30 -translate-x-1/2 rounded-full border border-gray-200 bg-white/95 px-3 py-1.5 text-xs font-semibold text-gray-700 shadow-lg backdrop-blur transition-colors hover:border-blue-300 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
+                  Jump to live
+                  <span aria-hidden>↓</span>
+                </span>
+              </motion.button>
+            )}
+          </AnimatePresence>
+
           {/* Sticky Next Stage Button */}
           <div
             style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1rem)" }}
@@ -759,6 +831,8 @@ export default function DebatePage({ params }: DebatePageProps) {
             stages={stages}
             personaAName={debate.personaA.name}
             personaBName={debate.personaB.name}
+            open={transcriptOpen}
+            onOpenChange={setTranscriptOpen}
           />
         </div>
       )}

--- a/frontend/src/components/PersonaPicker.tsx
+++ b/frontend/src/components/PersonaPicker.tsx
@@ -3,8 +3,10 @@
 import { useState, useMemo } from "react";
 import { motion } from "framer-motion";
 import * as Dialog from "@radix-ui/react-dialog";
+import { Drawer } from "vaul";
 import { X, Search } from "lucide-react";
 import type { Persona } from "@/lib/api";
+import { useIsMobile } from "@/lib/use-media-query";
 
 interface PersonaPickerProps {
   personas: Persona[];
@@ -59,91 +61,84 @@ function PersonaCard({
   onClick: () => void;
   index: number;
 }) {
-  const { avatarUrl, summary, tone, phrases } = usePersonaData(persona);
+  const { avatarUrl, summary, style, tone, phrases, priorities } =
+    usePersonaData(persona);
+
+  const ring = selected
+    ? accentColor === "blue"
+      ? "border-blue-400 ring-2 ring-blue-200 bg-blue-50/70"
+      : "border-purple-400 ring-2 ring-purple-200 bg-purple-50/70"
+    : "border-gray-200 bg-white hover:border-gray-300";
 
   return (
     <motion.button
       type="button"
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       disabled={disabled}
-      initial={{ opacity: 0, y: 12 }}
+      initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{
-        delay: Math.min(index * 0.03, 0.4),
-        type: "spring",
-        stiffness: 500,
-        damping: 35,
-      }}
-      whileHover={!disabled ? { scale: 1.01 } : {}}
-      whileTap={!disabled ? { scale: 0.99 } : {}}
-      className={`group relative w-full overflow-hidden rounded-xl border text-left transition-all ${
-        selected
-          ? accentColor === "blue"
-            ? "border-blue-500 bg-blue-50/80 ring-2 ring-blue-500/30"
-            : "border-purple-500 bg-purple-50/80 ring-2 ring-purple-500/30"
-          : disabled
-            ? "cursor-not-allowed border-gray-100 bg-gray-50 opacity-40"
-            : "border-gray-200 bg-white hover:border-gray-300 hover:shadow-md"
+      transition={{ delay: Math.min(index * 0.02, 0.2) }}
+      className={`relative flex items-start gap-3 rounded-xl border-2 p-3 text-left transition-all sm:p-4 ${ring} ${
+        disabled
+          ? "cursor-not-allowed opacity-40"
+          : "cursor-pointer"
       }`}
     >
-      <div className="flex gap-3.5 p-3.5">
-        {/* Avatar — large and clear */}
-        {avatarUrl ? (
-          <img
-            src={avatarUrl}
-            alt={persona.name}
-            className="h-20 w-20 shrink-0 rounded-xl border border-gray-200/80 bg-gray-100 object-cover"
-          />
-        ) : (
-          <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-xl border border-gray-200 bg-gray-100 text-2xl font-bold text-gray-300">
-            {persona.name.charAt(0)}
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt={persona.name}
+          className="h-12 w-12 shrink-0 rounded-lg border border-gray-200 object-cover sm:h-14 sm:w-14"
+        />
+      ) : (
+        <div
+          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-lg text-lg font-bold text-white sm:h-14 sm:w-14 ${
+            accentColor === "blue"
+              ? "bg-gradient-to-br from-blue-500 to-blue-700"
+              : "bg-gradient-to-br from-purple-500 to-purple-700"
+          }`}
+        >
+          {persona.name.charAt(0)}
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-bold text-gray-900 sm:text-base">
+          {persona.name}
+        </div>
+        <div className="mt-0.5 line-clamp-2 text-xs italic text-gray-500">
+          {persona.tagline}
+        </div>
+        {summary && (
+          <div className="mt-1 hidden line-clamp-2 text-[11px] leading-snug text-gray-400 sm:block">
+            {summary}
           </div>
         )}
-
-        {/* Text content */}
-        <div className="min-w-0 flex-1">
-          {/* Name + selected badge */}
-          <div className="flex items-center gap-2">
-            <span className="text-[15px] font-bold text-gray-900 leading-tight">
-              {persona.name}
-            </span>
-            {selected && (
+        {phrases && phrases.length > 0 && (
+          <div className="mt-2 hidden flex-wrap gap-1 sm:flex">
+            {phrases.slice(0, 2).map((p, i) => (
               <span
-                className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white ${
-                  accentColor === "blue" ? "bg-blue-500" : "bg-purple-500"
-                }`}
+                key={i}
+                className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600"
               >
-                Selected
+                &ldquo;{p.length > 35 ? p.slice(0, 35) + "…" : p}&rdquo;
+              </span>
+            ))}
+          </div>
+        )}
+        {(style || tone) && !phrases?.length && (
+          <div className="mt-2 hidden flex-wrap gap-1 sm:flex">
+            {style && (
+              <span className="rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600">
+                {style.length > 40 ? style.slice(0, 40) + "…" : style}
               </span>
             )}
           </div>
-
-          {/* Tagline */}
-          <p className="mt-0.5 text-[13px] italic leading-snug text-gray-500 line-clamp-2">
-            {persona.tagline}
-          </p>
-
-          {/* Summary */}
-          {summary && (
-            <p className="mt-1.5 text-[12px] leading-relaxed text-gray-400 line-clamp-3">
-              {summary}
-            </p>
-          )}
-
-          {/* Signature phrases as small pills */}
-          {phrases && phrases.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1">
-              {phrases.slice(0, 3).map((phrase) => (
-                <span
-                  key={phrase}
-                  className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-[10px] text-gray-500 leading-tight"
-                >
-                  &ldquo;{phrase.length > 30 ? phrase.slice(0, 30) + "…" : phrase}&rdquo;
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
+        )}
+        {priorities && priorities.length > 0 && (
+          <div className="mt-1 hidden text-[10px] text-gray-400 sm:block">
+            {priorities.slice(0, 2).join(" · ")}
+          </div>
+        )}
       </div>
     </motion.button>
   );
@@ -160,8 +155,7 @@ export default function PersonaPicker({
 }: PersonaPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
-  // Radix Dialog handles focus trap, Esc, scroll lock, ARIA roles, and portal
-  // out of the box — the previous hand-rolled modal is gone.
+  const isMobile = useIsMobile();
 
   const accentColor = side === "A" ? "blue" : "purple";
 
@@ -178,122 +172,223 @@ export default function PersonaPicker({
     };
   }, [personas, search]);
 
-  return (
-    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
-      <Dialog.Trigger asChild>
-        <button
-          type="button"
-          disabled={loading}
-          className={`w-full rounded-xl border px-4 py-3 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
-            accentColor === "blue"
-              ? "focus-visible:ring-blue-500"
-              : "focus-visible:ring-purple-500"
-          } ${
-            selected
-              ? accentColor === "blue"
-                ? "border-blue-300 bg-blue-50"
-                : "border-purple-300 bg-purple-50"
-              : "border-gray-200 bg-white hover:border-gray-300"
-          } ${loading ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
-        >
-        {loading ? (
-          <span className="text-sm text-gray-400">Loading...</span>
-        ) : selected ? (
-          <div className="flex items-center gap-3">
-            {(() => {
-              const raw = selected.personaJson as Record<string, unknown>;
-              const identity = raw.identity as
-                | Record<string, unknown>
-                | undefined;
-              const avatarUrl = (identity?.avatarUrl ?? raw.avatarUrl) as
-                | string
-                | undefined;
-              return avatarUrl ? (
-                <img
-                  src={avatarUrl}
-                  alt={selected.name}
-                  className="h-10 w-10 shrink-0 rounded-lg border border-gray-200 object-cover"
-                />
-              ) : null;
-            })()}
-            <div className="min-w-0 flex-1">
-              <div className="text-sm font-semibold text-gray-900">
-                {selected.name}
-              </div>
-              <div className="text-xs italic text-gray-500 line-clamp-1">
-                {selected.tagline}
-              </div>
+  const totalCount = templates.length + custom.length;
+
+  const triggerButton = (
+    <button
+      type="button"
+      disabled={loading}
+      className={`w-full rounded-xl border px-4 py-3 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
+        accentColor === "blue"
+          ? "focus-visible:ring-blue-500"
+          : "focus-visible:ring-purple-500"
+      } ${
+        selected
+          ? accentColor === "blue"
+            ? "border-blue-300 bg-blue-50"
+            : "border-purple-300 bg-purple-50"
+          : "border-gray-200 bg-white hover:border-gray-300"
+      } ${loading ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+    >
+      {loading ? (
+        <span className="text-sm text-gray-400">Loading...</span>
+      ) : selected ? (
+        <div className="flex items-center gap-3">
+          {(() => {
+            const raw = selected.personaJson as Record<string, unknown>;
+            const identity = raw.identity as Record<string, unknown> | undefined;
+            const avatarUrl = (identity?.avatarUrl ?? raw.avatarUrl) as
+              | string
+              | undefined;
+            return avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt={selected.name}
+                className="h-10 w-10 shrink-0 rounded-lg border border-gray-200 object-cover"
+              />
+            ) : null;
+          })()}
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold text-gray-900">
+              {selected.name}
             </div>
-            <svg
-              className="h-4 w-4 shrink-0 text-gray-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
-              />
-            </svg>
+            <div className="text-xs italic text-gray-500 line-clamp-1">
+              {selected.tagline}
+            </div>
           </div>
-        ) : (
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-400">
-              Select {pickerLabel}...
-            </span>
-            <svg
-              className="h-4 w-4 text-gray-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
-              />
-            </svg>
+          <svg
+            className="h-4 w-4 shrink-0 text-gray-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+            />
+          </svg>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-400">Select {pickerLabel}...</span>
+          <svg
+            className="h-4 w-4 text-gray-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8.25 15L12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+            />
+          </svg>
+        </div>
+      )}
+    </button>
+  );
+
+  const titleText =
+    pickerLabel === "guest"
+      ? `Guest ${side === "A" ? "1" : "2"}`
+      : side === "A"
+      ? "For Side Debater"
+      : "Against Side Debater";
+
+  /** Inner body of the picker — identical for both sheet and dialog. */
+  const body = (
+    <>
+      {/* Search */}
+      <div className="border-b border-gray-100 px-4 py-3 sm:px-6">
+        <div className="relative">
+          <Search
+            aria-hidden
+            className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          />
+          <input
+            type="text"
+            placeholder="Search by name or topic..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus={!isMobile /* on mobile autofocus pops the keyboard, worse UX */}
+            className="w-full rounded-lg border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-4 text-base text-gray-900 placeholder-gray-400 outline-none transition-colors focus:border-blue-300 focus:ring-2 focus:ring-blue-100 sm:text-sm"
+          />
+        </div>
+      </div>
+
+      {/* List */}
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6 sm:py-5">
+        {templates.length > 0 && (
+          <div className="mb-6">
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-xs font-bold uppercase tracking-wider text-gray-400">
+                Curated Personas
+              </span>
+              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-500">
+                {templates.length}
+              </span>
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {templates.map((p, i) => (
+                <PersonaCard
+                  key={p.id}
+                  persona={p}
+                  selected={selected?.id === p.id}
+                  disabled={p.id === disabledId}
+                  accentColor={accentColor}
+                  index={i}
+                  onClick={() => {
+                    onSelect(p);
+                    setIsOpen(false);
+                    setSearch("");
+                  }}
+                />
+              ))}
+            </div>
           </div>
         )}
-        </button>
-      </Dialog.Trigger>
 
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/30 backdrop-blur-sm data-[state=open]:animate-[fade-in_150ms] data-[state=closed]:animate-[fade-out_100ms]" />
-        <Dialog.Content
-          aria-describedby={undefined}
-          className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[calc(100vw-2rem)] max-w-6xl max-h-[90vh] rounded-2xl border border-gray-200 bg-white shadow-2xl flex flex-col overflow-hidden sm:w-[calc(100vw-4rem)] lg:w-[90vw] data-[state=open]:animate-[dialog-in_200ms] data-[state=closed]:animate-[dialog-out_150ms]"
-        >
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="flex flex-1 min-h-0 flex-col"
+        {(custom.length > 0 || templates.length > 0) && (
+          <div>
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-xs font-bold uppercase tracking-wider text-gray-400">
+                Custom Personas
+              </span>
+              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-500">
+                {custom.length}
+              </span>
+            </div>
+            {custom.length > 0 ? (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {custom.map((p, i) => (
+                  <PersonaCard
+                    key={p.id}
+                    persona={p}
+                    selected={selected?.id === p.id}
+                    disabled={p.id === disabledId}
+                    accentColor={accentColor}
+                    index={templates.length + i}
+                    onClick={() => {
+                      onSelect(p);
+                      setIsOpen(false);
+                      setSearch("");
+                    }}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-xl border-2 border-dashed border-gray-200 px-4 py-6 text-center">
+                <p className="text-sm text-gray-400">
+                  No custom personas yet
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {templates.length === 0 && custom.length === 0 && (
+          <div className="py-12 text-center">
+            <p className="text-sm text-gray-400">
+              No personas match &ldquo;{search}&rdquo;
+            </p>
+          </div>
+        )}
+      </div>
+    </>
+  );
+
+  // Mobile: Vaul bottom sheet (drag handle, swipe-to-dismiss, uses full height).
+  if (isMobile) {
+    return (
+      <Drawer.Root open={isOpen} onOpenChange={setIsOpen}>
+        <Drawer.Trigger asChild>{triggerButton}</Drawer.Trigger>
+        <Drawer.Portal>
+          <Drawer.Overlay className="fixed inset-0 z-50 bg-black/40" />
+          <Drawer.Content
+            aria-describedby={undefined}
+            className="fixed inset-x-0 bottom-0 z-50 flex max-h-[92dvh] flex-col rounded-t-2xl border border-b-0 border-gray-200 bg-white shadow-2xl outline-none"
           >
+            <div className="mx-auto mt-2 h-1.5 w-10 shrink-0 rounded-full bg-gray-300" />
             {/* Header */}
             <div
-              className={`flex items-center justify-between border-b px-4 py-3 sm:px-6 sm:py-4 ${
+              className={`flex items-center justify-between border-b px-4 py-3 ${
                 accentColor === "blue"
                   ? "border-blue-100 bg-blue-50/50"
                   : "border-purple-100 bg-purple-50/50"
               }`}
             >
               <div>
-                <Dialog.Title className="text-lg font-bold text-gray-900">
-                  Choose{" "}
-                  {pickerLabel === "guest"
-                    ? `Guest ${side === "A" ? "1" : "2"}`
-                    : side === "A"
-                    ? "For Side Debater"
-                    : "Against Side Debater"}
-                </Dialog.Title>
+                <Drawer.Title className="text-base font-bold text-gray-900">
+                  Choose {titleText}
+                </Drawer.Title>
                 <p className="mt-0.5 text-xs text-gray-500">
-                  {templates.length + custom.length} personas available
+                  {totalCount} personas available
                 </p>
               </div>
-              <Dialog.Close asChild>
+              <Drawer.Close asChild>
                 <button
                   type="button"
                   aria-label="Close"
@@ -301,110 +396,54 @@ export default function PersonaPicker({
                 >
                   <X aria-hidden className="h-5 w-5" />
                 </button>
-              </Dialog.Close>
+              </Drawer.Close>
             </div>
+            {body}
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    );
+  }
 
-                  {/* Search */}
-                  <div className="border-b border-gray-100 px-4 py-3 sm:px-6">
-                    <div className="relative">
-                      <Search
-                        aria-hidden
-                        className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
-                      />
-                      <input
-                        type="text"
-                        placeholder="Search by name or topic..."
-                        value={search}
-                        onChange={(e) => setSearch(e.target.value)}
-                        autoFocus
-                        className="w-full rounded-lg border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-4 text-base text-gray-900 placeholder-gray-400 outline-none transition-colors focus:border-blue-300 focus:ring-2 focus:ring-blue-100 sm:text-sm"
-                      />
-                    </div>
-                  </div>
-
-                  {/* List */}
-                  <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">
-                    {/* Templates section */}
-                    {templates.length > 0 && (
-                      <div className="mb-6">
-                        <div className="mb-3 flex items-center gap-2">
-                          <span className="text-xs font-bold uppercase tracking-wider text-gray-400">
-                            Curated Personas
-                          </span>
-                          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-500">
-                            {templates.length}
-                          </span>
-                        </div>
-                        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                          {templates.map((p, i) => (
-                            <PersonaCard
-                              key={p.id}
-                              persona={p}
-                              selected={selected?.id === p.id}
-                              disabled={p.id === disabledId}
-                              accentColor={accentColor}
-                              index={i}
-                              onClick={() => {
-                                onSelect(p);
-                                setIsOpen(false);
-                                setSearch("");
-                              }}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Custom section */}
-                    {(custom.length > 0 || templates.length > 0) && (
-                      <div>
-                        <div className="mb-3 flex items-center gap-2">
-                          <span className="text-xs font-bold uppercase tracking-wider text-gray-400">
-                            Custom Personas
-                          </span>
-                          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-500">
-                            {custom.length}
-                          </span>
-                        </div>
-                        {custom.length > 0 ? (
-                          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                            {custom.map((p, i) => (
-                              <PersonaCard
-                                key={p.id}
-                                persona={p}
-                                selected={selected?.id === p.id}
-                                disabled={p.id === disabledId}
-                                accentColor={accentColor}
-                                index={templates.length + i}
-                                onClick={() => {
-                                  onSelect(p);
-                                  setIsOpen(false);
-                                  setSearch("");
-                                }}
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          <div className="rounded-xl border-2 border-dashed border-gray-200 px-4 py-6 text-center">
-                            <p className="text-sm text-gray-400">
-                              No custom personas yet
-                            </p>
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-            {templates.length === 0 && custom.length === 0 && (
-              <div className="py-12 text-center">
-                <p className="text-sm text-gray-400">
-                  No personas match &ldquo;{search}&rdquo;
-                </p>
-              </div>
-            )}
-              </div>
-            </motion.div>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+  // Desktop: centered Radix Dialog.
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
+      <Dialog.Trigger asChild>{triggerButton}</Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/30 backdrop-blur-sm data-[state=open]:animate-[fade-in_150ms] data-[state=closed]:animate-[fade-out_100ms]" />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[calc(100vw-4rem)] max-w-6xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl lg:w-[90vw] data-[state=open]:animate-[dialog-in_200ms] data-[state=closed]:animate-[dialog-out_150ms]"
+        >
+          {/* Header */}
+          <div
+            className={`flex items-center justify-between border-b px-4 py-3 sm:px-6 sm:py-4 ${
+              accentColor === "blue"
+                ? "border-blue-100 bg-blue-50/50"
+                : "border-purple-100 bg-purple-50/50"
+            }`}
+          >
+            <div>
+              <Dialog.Title className="text-lg font-bold text-gray-900">
+                Choose {titleText}
+              </Dialog.Title>
+              <p className="mt-0.5 text-xs text-gray-500">
+                {totalCount} personas available
+              </p>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Close"
+                className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+              >
+                <X aria-hidden className="h-5 w-5" />
+              </button>
+            </Dialog.Close>
+          </div>
+          {body}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/frontend/src/components/StatsDashboard.tsx
+++ b/frontend/src/components/StatsDashboard.tsx
@@ -70,7 +70,7 @@ function HeroStatsBar({ stats }: { stats: AllStats }) {
     "sm:col-span-2", // Most Active (wide)
   ];
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 sm:auto-rows-[minmax(72px,auto)]">
+    <div className="grid grid-cols-1 gap-3 [@media(min-width:480px)]:grid-cols-2 sm:grid-cols-4 sm:auto-rows-[minmax(72px,auto)]">
       {cards.map((card, i) => {
         const span = bentoClasses[i] ?? "";
         const isHero = i === 0;
@@ -80,7 +80,7 @@ function HeroStatsBar({ stats }: { stats: AllStats }) {
             style={{ animationDelay: `${i * 50}ms` }}
             className={`enter-up cursor-pointer rounded-xl border border-gray-200/80 bg-white/80 shadow-sm backdrop-blur transition-colors hover:bg-gray-50 ${span} ${
               isHero
-                ? "flex flex-col justify-between bg-gradient-to-br from-white to-blue-50/40 px-4 py-4"
+                ? "flex flex-col justify-between bg-gradient-to-br from-white to-blue-50/40 px-4 py-3 sm:py-4"
                 : "px-3 py-2"
             }`}
           >

--- a/frontend/src/components/TranscriptDrawer.tsx
+++ b/frontend/src/components/TranscriptDrawer.tsx
@@ -10,6 +10,13 @@ interface TranscriptDrawerProps {
   stages: StageConfig[];
   personaAName: string;
   personaBName: string;
+  /**
+   * Optional externally-controlled open state. When provided, the drawer is
+   * controlled by the parent and the component's built-in mobile toggle FAB
+   * is hidden (parent is expected to render its own trigger).
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const speakerColor: Record<Speaker, string> = {
@@ -31,8 +38,16 @@ export default function TranscriptDrawer({
   stages,
   personaAName,
   personaBName,
+  open,
+  onOpenChange,
 }: TranscriptDrawerProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const isControlled = open !== undefined && onOpenChange !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = isControlled ? open : internalOpen;
+  const setIsOpen = (v: boolean) => {
+    if (isControlled) onOpenChange(v);
+    else setInternalOpen(v);
+  };
 
   function scrollToStage(stageId: string) {
     const element = document.getElementById(`stage-${stageId}`);
@@ -66,15 +81,23 @@ export default function TranscriptDrawer({
 
   return (
     <>
-      {/* Toggle Button */}
+      {/* Toggle Button — desktop only when externally controlled. On mobile,
+          the parent page supplies its own trigger (in the sticky subheader)
+          to avoid crowding the thumb zone with two floating elements. */}
       <button
         onClick={() => setIsOpen(!isOpen)}
         aria-label={isOpen ? "Close transcript" : "Open transcript"}
-        style={{
-          bottom: "calc(env(safe-area-inset-bottom, 0px) + 5.25rem)",
-          right: "calc(env(safe-area-inset-right, 0px) + 1rem)",
-        }}
-        className="fixed z-40 flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-600 shadow-md backdrop-blur transition-all hover:border-blue-300 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 lg:bottom-auto lg:right-auto lg:left-4 lg:top-24 lg:h-10 lg:w-10 lg:border-0 lg:bg-gradient-to-r lg:from-blue-500 lg:to-purple-600 lg:text-white lg:shadow-lg lg:shadow-blue-500/25"
+        style={
+          isControlled
+            ? undefined
+            : {
+                bottom: "calc(env(safe-area-inset-bottom, 0px) + 5.25rem)",
+                right: "calc(env(safe-area-inset-right, 0px) + 1rem)",
+              }
+        }
+        className={`${
+          isControlled ? "hidden lg:flex" : "fixed flex"
+        } z-40 h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white/95 text-gray-600 shadow-md backdrop-blur transition-all hover:border-blue-300 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 lg:fixed lg:bottom-auto lg:right-auto lg:left-4 lg:top-24 lg:h-10 lg:w-10 lg:border-0 lg:bg-gradient-to-r lg:from-blue-500 lg:to-purple-600 lg:text-white lg:shadow-lg lg:shadow-blue-500/25`}
       >
         <svg
           className={`h-5 w-5 transition-transform ${isOpen ? "rotate-180" : ""}`}

--- a/frontend/src/lib/use-media-query.ts
+++ b/frontend/src/lib/use-media-query.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Match a CSS media query client-side. Returns false on first render (SSR-safe),
+ * then flips to the real value on mount. Subscribes to changes so viewport
+ * rotation / DevTools resizing works too.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const update = () => setMatches(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, [query]);
+  return matches;
+}
+
+/** Tailwind's `md` breakpoint is 768px. Mobile = below that. */
+export function useIsMobile(): boolean {
+  return !useMediaQuery("(min-width: 768px)");
+}


### PR DESCRIPTION
Research + audit → 4 high-leverage changes:

1. **PersonaPicker bottom sheet** (Vaul) on <md breakpoint, Radix Dialog on desktop. Phones get a native-feeling sheet with drag-to-dismiss, drag handle, full-height.
2. **Transcript toggle moved into debate subheader** on mobile. Only one floating element at the thumb-zone now (the Next Stage CTA).
3. **Stats bento → single column below 480px**, 2-col at 480-640, 4-col bento at ≥640.
4. **Jump-to-live pill** during streaming + sticky-bottom-unless-scrolled auto-scroll.

Plus StreamingTurnCard mobile padding tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)