### PR TITLE
Unify streaming + saved speech cards · polished presentation

### DIFF
--- a/frontend/src/app/debate/[id]/page.tsx
+++ b/frontend/src/app/debate/[id]/page.tsx
@@ -383,11 +383,56 @@ interface StreamingTurnCardProps {
   avatarUrl?: string;
 }
 
-const ghostTones: Record<Speaker, { bg: string; border: string; ring: string; text: string }> = {
-  A: { bg: "bg-blue-50/80", border: "border-blue-200", ring: "ring-blue-300", text: "text-blue-900" },
-  B: { bg: "bg-purple-50/80", border: "border-purple-200", ring: "ring-purple-300", text: "text-purple-900" },
-  MOD: { bg: "bg-amber-50/80", border: "border-amber-200", ring: "ring-amber-300", text: "text-amber-900" },
-  JUDGE: { bg: "bg-emerald-50/80", border: "border-emerald-200", ring: "ring-emerald-300", text: "text-emerald-900" },
+// Matches SpeechCard's visual language exactly so the live → saved transition
+// is seamless. Only differences: "LIVE" chip in place of the role badge, and a
+// blinking caret at the end of the narrative.
+const streamingTone: Record<
+  Speaker,
+  {
+    border: string;
+    accentBorder: string;
+    headerBg: string;
+    avatarRing: string;
+    avatarFallback: string;
+    dropCap: string;
+  }
+> = {
+  A: {
+    border: "border-blue-200",
+    accentBorder: "border-l-blue-500",
+    headerBg:
+      "bg-gradient-to-r from-blue-50 via-blue-50/60 to-transparent",
+    avatarRing: "ring-blue-300",
+    avatarFallback: "bg-blue-100 text-blue-700",
+    dropCap: "text-blue-600",
+  },
+  B: {
+    border: "border-purple-200",
+    accentBorder: "border-l-purple-500",
+    headerBg:
+      "bg-gradient-to-r from-purple-50 via-purple-50/60 to-transparent",
+    avatarRing: "ring-purple-300",
+    avatarFallback: "bg-purple-100 text-purple-700",
+    dropCap: "text-purple-600",
+  },
+  MOD: {
+    border: "border-amber-200",
+    accentBorder: "border-l-amber-500",
+    headerBg:
+      "bg-gradient-to-r from-amber-50 via-amber-50/60 to-transparent",
+    avatarRing: "ring-amber-300",
+    avatarFallback: "bg-amber-100 text-amber-800",
+    dropCap: "text-amber-700",
+  },
+  JUDGE: {
+    border: "border-emerald-200",
+    accentBorder: "border-l-emerald-500",
+    headerBg:
+      "bg-gradient-to-r from-emerald-50 via-emerald-50/60 to-transparent",
+    avatarRing: "ring-emerald-300",
+    avatarFallback: "bg-emerald-100 text-emerald-800",
+    dropCap: "text-emerald-700",
+  },
 };
 
 function StreamingTurnCard({
@@ -397,42 +442,76 @@ function StreamingTurnCard({
   text,
   avatarUrl,
 }: StreamingTurnCardProps) {
-  const tone = (speaker && ghostTones[speaker]) || ghostTones.MOD;
+  const tone = (speaker && streamingTone[speaker]) || streamingTone.MOD;
+  const hasDropCap = text.length > 40;
+  const firstChar = text.trimStart().slice(0, 1);
+  const rest = text.trimStart().slice(1);
+
   return (
-    <motion.div
+    <motion.article
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
-      className={`relative rounded-2xl border ${tone.border} ${tone.bg} p-3 shadow-sm sm:p-5`}
+      className={`relative overflow-hidden rounded-2xl border-l-4 border-y border-r shadow-sm ${tone.border} ${tone.accentBorder} bg-white ring-1 ring-black/5`}
     >
-      <div className="mb-2.5 flex items-center gap-2.5 sm:mb-3 sm:gap-3">
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute right-0 top-0 h-24 w-24 rounded-bl-full opacity-50 ${tone.headerBg}`}
+      />
+      {/* Header */}
+      <header
+        className={`relative flex items-center gap-3 border-b ${tone.border} px-4 py-3 sm:px-5`}
+      >
         {avatarUrl ? (
           <img
             src={avatarUrl}
             alt={speakerName}
-            className={`h-9 w-9 shrink-0 rounded-full object-cover ring-2 sm:h-10 sm:w-10 ${tone.ring}`}
+            className={`h-10 w-10 shrink-0 rounded-full object-cover ring-2 sm:h-11 sm:w-11 ${tone.avatarRing}`}
           />
         ) : (
           <div
-            className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white text-sm font-bold ring-2 sm:h-10 sm:w-10 ${tone.ring} ${tone.text}`}
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ring-2 sm:h-11 sm:w-11 ${tone.avatarRing} ${tone.avatarFallback}`}
           >
             {speakerName ? speakerName.charAt(0) : "?"}
           </div>
         )}
         <div className="min-w-0 flex-1">
-          <div className={`truncate text-sm font-bold ${tone.text}`}>{speakerName || "Generating…"}</div>
-          <div className="truncate text-[11px] uppercase tracking-wider text-gray-500">{stageLabel}</div>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <h3 className="truncate text-[15px] font-bold leading-tight text-gray-900 sm:text-base">
+              {speakerName || "Generating…"}
+            </h3>
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-white px-2 py-0.5 font-[var(--font-cinzel)] text-[9px] font-bold uppercase tracking-[0.12em] text-emerald-700 shadow-sm ring-1 ring-emerald-200">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
+              Live
+            </span>
+          </div>
+          <p className="mt-0.5 truncate text-[11px] uppercase tracking-[0.15em] text-gray-400">
+            {stageLabel}
+          </p>
         </div>
-        <span className="inline-flex items-center gap-1 rounded-full bg-white/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-gray-500">
-          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
-          live
-        </span>
+      </header>
+
+      {/* Body */}
+      <div className="relative px-4 py-4 sm:px-6 sm:py-5">
+        <p className="whitespace-pre-wrap text-[15px] leading-[1.65] text-gray-800 sm:text-[16px]">
+          {hasDropCap ? (
+            <>
+              <span
+                className={`float-left mr-1.5 mt-[2px] font-[var(--font-playfair)] text-[48px] font-black leading-[0.85] sm:text-[56px] ${tone.dropCap}`}
+                aria-hidden
+              >
+                {firstChar}
+              </span>
+              <span className="sr-only">{firstChar}</span>
+              {rest}
+            </>
+          ) : (
+            text
+          )}
+          <span className="ml-0.5 inline-block h-4 w-[2px] -translate-y-[1px] animate-pulse bg-gray-600 align-middle" />
+        </p>
       </div>
-      <p className={`whitespace-pre-wrap text-[15px] leading-relaxed ${tone.text}`}>
-        {text}
-        <span className="ml-0.5 inline-block h-4 w-[2px] -translate-y-[1px] animate-pulse bg-current align-middle" />
-      </p>
-    </motion.div>
+    </motion.article>
   );
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -123,6 +123,64 @@ html {
   to { opacity: 0; transform: translate(-50%, -50%) scale(0.96) translateY(10px); }
 }
 
+/* Additional enter variants used during the Framer Motion rip. */
+.enter-up-fast { animation: enter-up 250ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+.enter-fade-fast { animation: enter-fade 200ms ease-out both; }
+.enter-left { animation: enter-left 350ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+.enter-right { animation: enter-right 350ms cubic-bezier(0.22, 1, 0.36, 1) both; }
+.enter-spring-pop { animation: spring-pop 400ms cubic-bezier(0.25, 1.4, 0.5, 1) both; }
+.enter-breath { animation: breath 4.5s ease-in-out infinite; }
+
+@keyframes enter-left {
+  from { opacity: 0; transform: translateX(-10px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes enter-right {
+  from { opacity: 0; transform: translateX(10px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes spring-pop {
+  0% { opacity: 0; transform: scale(0.8); }
+  60% { opacity: 1; transform: scale(1.02); }
+  100% { opacity: 1; transform: scale(1); }
+}
+@keyframes breath {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.012); }
+}
+
+/* Exit animations — used with useDelayedUnmount hook. */
+.exit-fade { animation: exit-fade 150ms ease-in both; }
+.exit-up { animation: exit-up 180ms ease-in both; }
+.exit-down { animation: exit-down 180ms ease-in both; }
+
+@keyframes exit-fade {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@keyframes exit-up {
+  from { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateY(-8px); }
+}
+@keyframes exit-down {
+  from { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateY(8px); }
+}
+
+/* Interactive micro-interactions (replaces whileHover / whileTap). */
+.press-scale {
+  transition: transform 150ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.press-scale:hover { transform: scale(1.02); }
+.press-scale:active { transform: scale(0.98); }
+
+/* Pulsing ring around the active stage tick in StageProgressTracker. */
+.stage-pulse { animation: stage-pulse 2s ease-in-out infinite; }
+@keyframes stage-pulse {
+  0%, 100% { transform: scale(1); opacity: 0.6; }
+  50% { transform: scale(1.3); opacity: 0; }
+}
+
 /* Skeleton shimmer for pre-TTFT loading states. */
 @keyframes shimmer {
   0% { background-position: -200% 0; }

--- a/frontend/src/components/SpeechCard.tsx
+++ b/frontend/src/components/SpeechCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { motion } from "framer-motion";
 import type { Turn, Speaker, TurnPayload } from "@/lib/api";
 
 interface SpeechCardProps {
@@ -11,49 +10,89 @@ interface SpeechCardProps {
   isLatest: boolean;
 }
 
-const bubbleColors: Record<Speaker, { bg: string; border: string; tail: string; text: string }> = {
+type Tone = {
+  cardBg: string;
+  cardBorder: string;
+  headerBg: string;
+  accentBorder: string;
+  avatarRing: string;
+  avatarFallback: string;
+  badgeBg: string;
+  badgeText: string;
+  badgeLabel: string;
+  rule: string;
+  dropCap: string;
+  quoteGlyph: string;
+};
+
+const toneMap: Record<Speaker, Tone> = {
   A: {
-    bg: "bg-blue-50",
-    border: "border-blue-200",
-    tail: "text-blue-200",
-    text: "text-blue-900",
+    cardBg: "bg-white",
+    cardBorder: "border-blue-200",
+    headerBg:
+      "bg-gradient-to-r from-blue-50 via-blue-50/60 to-transparent",
+    accentBorder: "border-l-blue-500",
+    avatarRing: "ring-blue-300",
+    avatarFallback: "bg-blue-100 text-blue-700",
+    badgeBg: "bg-blue-100",
+    badgeText: "text-blue-700",
+    badgeLabel: "For",
+    rule: "bg-blue-100",
+    dropCap: "text-blue-600",
+    quoteGlyph: "text-blue-300",
   },
   B: {
-    bg: "bg-purple-50",
-    border: "border-purple-200",
-    tail: "text-purple-200",
-    text: "text-purple-900",
+    cardBg: "bg-white",
+    cardBorder: "border-purple-200",
+    headerBg:
+      "bg-gradient-to-r from-purple-50 via-purple-50/60 to-transparent",
+    accentBorder: "border-l-purple-500",
+    avatarRing: "ring-purple-300",
+    avatarFallback: "bg-purple-100 text-purple-700",
+    badgeBg: "bg-purple-100",
+    badgeText: "text-purple-700",
+    badgeLabel: "Against",
+    rule: "bg-purple-100",
+    dropCap: "text-purple-600",
+    quoteGlyph: "text-purple-300",
   },
   MOD: {
-    bg: "bg-amber-50",
-    border: "border-amber-200",
-    tail: "text-amber-200",
-    text: "text-amber-900",
+    cardBg: "bg-white",
+    cardBorder: "border-amber-200",
+    headerBg:
+      "bg-gradient-to-r from-amber-50 via-amber-50/60 to-transparent",
+    accentBorder: "border-l-amber-500",
+    avatarRing: "ring-amber-300",
+    avatarFallback: "bg-amber-100 text-amber-800",
+    badgeBg: "bg-amber-100",
+    badgeText: "text-amber-800",
+    badgeLabel: "Moderator",
+    rule: "bg-amber-100",
+    dropCap: "text-amber-700",
+    quoteGlyph: "text-amber-300",
   },
   JUDGE: {
-    bg: "bg-emerald-50",
-    border: "border-emerald-200",
-    tail: "text-emerald-200",
-    text: "text-emerald-900",
+    cardBg: "bg-white",
+    cardBorder: "border-emerald-200",
+    headerBg:
+      "bg-gradient-to-r from-emerald-50 via-emerald-50/60 to-transparent",
+    accentBorder: "border-l-emerald-500",
+    avatarRing: "ring-emerald-300",
+    avatarFallback: "bg-emerald-100 text-emerald-800",
+    badgeBg: "bg-emerald-100",
+    badgeText: "text-emerald-800",
+    badgeLabel: "Judge",
+    rule: "bg-emerald-100",
+    dropCap: "text-emerald-700",
+    quoteGlyph: "text-emerald-300",
   },
 };
 
-const avatarRing: Record<Speaker, string> = {
-  A: "ring-blue-300",
-  B: "ring-purple-300",
-  MOD: "ring-amber-300",
-  JUDGE: "ring-emerald-300",
-};
-
-function getSlideDirection(speaker: Speaker): { x: number } {
-  switch (speaker) {
-    case "A":
-      return { x: -30 };
-    case "B":
-      return { x: 30 };
-    default:
-      return { x: 0 };
-  }
+function firstWords(text: string, maxChars = 1000): { first: string; rest: string } {
+  // Split off the first character so we can drop-cap it.
+  const trimmed = text.trimStart();
+  if (!trimmed) return { first: "", rest: "" };
+  return { first: trimmed.slice(0, 1), rest: trimmed.slice(1, maxChars) };
 }
 
 export default function SpeechCard({
@@ -63,176 +102,172 @@ export default function SpeechCard({
   avatarUrl,
   isLatest,
 }: SpeechCardProps) {
-  const colors = bubbleColors[turn.speaker];
-  const slide = getSlideDirection(turn.speaker);
+  const tone = toneMap[turn.speaker];
   const payload = turn.payload as TurnPayload;
 
-  const isLeft = turn.speaker === "A";
-  const isRight = turn.speaker === "B";
-  const isCentered = !isLeft && !isRight;
-
-  const avatar = (
-    <>
-      {avatarUrl ? (
-        <motion.img
-          src={avatarUrl}
-          alt={speakerName}
-          initial={{ scale: 0 }}
-          animate={{ scale: 1 }}
-          transition={{ delay: isLatest ? 0.1 : 0, type: "spring", stiffness: 300 }}
-          className={`h-10 w-10 shrink-0 rounded-full object-cover ring-2 ${avatarRing[turn.speaker]} shadow-md`}
-        />
-      ) : (
-        <div
-          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xs font-bold ring-2 ${avatarRing[turn.speaker]} ${colors.bg} ${colors.text} shadow-md`}
-        >
-          {speakerName.charAt(0)}
-        </div>
-      )}
-    </>
+  const avatar = avatarUrl ? (
+    <img
+      src={avatarUrl}
+      alt={speakerName}
+      className={`h-10 w-10 shrink-0 rounded-full object-cover ring-2 ${tone.avatarRing} shadow-sm sm:h-11 sm:w-11`}
+    />
+  ) : (
+    <div
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ring-2 sm:h-11 sm:w-11 ${tone.avatarRing} ${tone.avatarFallback}`}
+    >
+      {speakerName.charAt(0)}
+    </div>
   );
 
+  const narrative = payload.narrative ?? payload.lead ?? "";
+  const hasDropCap = narrative.length > 40;
+  const { first, rest } = firstWords(narrative);
+  const paragraphs = narrative.split("\n\n");
+
   return (
-    <motion.div
+    <article
       id={`stage-${turn.stageId}`}
-      initial={{ opacity: 0, x: slide.x, y: 10 }}
-      animate={{ opacity: 1, x: 0, y: 0 }}
-      transition={{
-        duration: 0.5,
-        delay: isLatest ? 0.2 : 0,
-        ease: [0.25, 0.46, 0.45, 0.94],
-      }}
-      className={`flex items-end gap-3 ${
-        isRight ? "flex-row-reverse" : ""
+      className={`enter-up group relative overflow-hidden rounded-2xl border-l-4 border-y border-r ${tone.cardBorder} ${tone.accentBorder} ${tone.cardBg} shadow-sm transition-shadow hover:shadow-md ${
+        isLatest ? "ring-1 ring-black/5" : ""
       }`}
     >
-      {/* Avatar — only for A/B */}
-      {!isCentered && avatar}
+      {/* Decorative corner ornament — subtle, picks up the tone color */}
+      <div
+        aria-hidden
+        className={`pointer-events-none absolute right-0 top-0 h-24 w-24 rounded-bl-full opacity-50 ${tone.headerBg}`}
+      />
 
-      {/* Bubble — stretches full width */}
-      <div className="relative min-w-0 flex-1">
-        {/* Speech tail */}
-        {isLeft && (
-          <div className={`absolute -left-2 bottom-3 ${colors.tail}`}>
-            <svg width="12" height="16" viewBox="0 0 12 16" fill="none">
-              <path d="M12 0C12 0 4 4 2 8C0 12 0 16 0 16L12 12V0Z" fill="currentColor" />
-            </svg>
+      {/* Header — avatar · byline · role badge */}
+      <header
+        className={`relative flex items-center gap-3 border-b ${tone.cardBorder} px-4 py-3 sm:px-5`}
+      >
+        {avatar}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <h3 className="truncate text-[15px] font-bold leading-tight text-gray-900 sm:text-base">
+              {speakerName}
+            </h3>
+            <span
+              className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 font-[var(--font-cinzel)] text-[9px] font-bold uppercase tracking-[0.12em] ${tone.badgeBg} ${tone.badgeText}`}
+            >
+              {tone.badgeLabel}
+            </span>
           </div>
-        )}
-        {isRight && (
-          <div className={`absolute -right-2 bottom-3 ${colors.tail}`}>
-            <svg width="12" height="16" viewBox="0 0 12 16" fill="none">
-              <path d="M0 0C0 0 8 4 10 8C12 12 12 16 12 16L0 12V0Z" fill="currentColor" />
-            </svg>
-          </div>
-        )}
-
-        <div
-          className={`overflow-hidden rounded-2xl border-2 ${colors.border} ${colors.bg} shadow-md ring-1 ring-black/5 ${
-            isLeft ? "rounded-bl-sm" : isRight ? "rounded-br-sm" : ""
-          }`}
-        >
-          {/* Body — no header row */}
-          <div className="px-4 py-3">
-            {/* Narrative prose */}
-            {payload.narrative && (
-              <div className="space-y-2">
-                {payload.narrative.split("\n\n").map((paragraph, i) => (
-                  <motion.p
-                    key={i}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ delay: isLatest ? 0.3 + i * 0.1 : 0 }}
-                    className="text-sm leading-relaxed text-gray-800"
-                  >
-                    {paragraph}
-                  </motion.p>
-                ))}
-              </div>
-            )}
-
-            {/* Legacy: lead + bullets */}
-            {!payload.narrative && payload.lead && (
-              <>
-                <p className="text-sm font-medium leading-relaxed text-gray-800">
-                  {payload.lead}
-                </p>
-                {payload.bullets && payload.bullets.length > 0 && (
-                  <ul className="mt-2 space-y-1.5">
-                    {payload.bullets.map((bullet, i) => (
-                      <motion.li
-                        key={i}
-                        initial={{ opacity: 0, x: -10 }}
-                        animate={{ opacity: 1, x: 0 }}
-                        transition={{ delay: isLatest ? 0.4 + i * 0.1 : 0 }}
-                        className="flex items-start gap-2 text-sm leading-relaxed text-gray-600"
-                      >
-                        <span
-                          className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${
-                            turn.speaker === "A"
-                              ? "bg-blue-400"
-                              : turn.speaker === "B"
-                              ? "bg-purple-400"
-                              : turn.speaker === "MOD"
-                              ? "bg-amber-400"
-                              : "bg-emerald-400"
-                          }`}
-                        />
-                        {bullet}
-                      </motion.li>
-                    ))}
-                  </ul>
-                )}
-              </>
-            )}
-
-            {/* Question block */}
-            {payload.question && (
-              <motion.div
-                initial={{ opacity: 0, y: 5 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: isLatest ? 0.6 : 0 }}
-                className="mt-3 rounded-lg border border-gray-200 bg-white/60 px-3 py-2"
-              >
-                <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
-                  Question
-                </p>
-                <p className="mt-0.5 text-sm italic text-gray-700">
-                  &ldquo;{payload.question}&rdquo;
-                </p>
-              </motion.div>
-            )}
-
-            {/* Question answered */}
-            {payload.questionAnswered && (
-              <motion.div
-                initial={{ opacity: 0, y: 5 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: isLatest ? 0.5 : 0 }}
-                className="mt-2 rounded-lg border border-gray-200 bg-white/60 px-3 py-2"
-              >
-                <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
-                  Answering
-                </p>
-                <p className="mt-0.5 text-sm text-gray-700">
-                  {payload.questionAnswered}
-                </p>
-              </motion.div>
-            )}
-
-            {/* Violations */}
-            {turn.violations.length > 0 && (
-              <div className="mt-2 space-y-1">
-                {turn.violations.map((v, i) => (
-                  <p key={i} className="text-xs text-red-500/70">
-                    * {v}
-                  </p>
-                ))}
-              </div>
-            )}
-          </div>
+          <p className="mt-0.5 truncate text-[11px] uppercase tracking-[0.15em] text-gray-400">
+            {stageLabel}
+          </p>
         </div>
+      </header>
+
+      {/* Body */}
+      <div className="relative px-4 py-4 sm:px-6 sm:py-5">
+        {/* Narrative prose */}
+        {payload.narrative && (
+          <div className="space-y-3 text-[15px] leading-[1.65] text-gray-800 sm:text-[16px]">
+            {paragraphs.map((paragraph, i) => {
+              if (i === 0 && hasDropCap) {
+                const { first: f, rest: r } = firstWords(paragraph);
+                return (
+                  <p key={i} className="first-letter:font-[var(--font-playfair)]">
+                    <span
+                      className={`float-left mr-1.5 mt-[2px] font-[var(--font-playfair)] text-[48px] font-black leading-[0.85] sm:text-[56px] ${tone.dropCap}`}
+                      aria-hidden
+                    >
+                      {f}
+                    </span>
+                    <span className="sr-only">{first}</span>
+                    {r}
+                  </p>
+                );
+              }
+              return (
+                <p key={i} className="text-gray-800">
+                  {paragraph}
+                </p>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Legacy: lead + bullets (no drop cap for these older turns) */}
+        {!payload.narrative && payload.lead && (
+          <>
+            <p className="text-[15px] font-medium leading-[1.65] text-gray-800 sm:text-[16px]">
+              {payload.lead}
+            </p>
+            {payload.bullets && payload.bullets.length > 0 && (
+              <ul className="mt-3 space-y-1.5">
+                {payload.bullets.map((bullet, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-sm leading-relaxed text-gray-700"
+                  >
+                    <span
+                      className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${
+                        turn.speaker === "A"
+                          ? "bg-blue-400"
+                          : turn.speaker === "B"
+                          ? "bg-purple-400"
+                          : turn.speaker === "MOD"
+                          ? "bg-amber-400"
+                          : "bg-emerald-400"
+                      }`}
+                    />
+                    {bullet}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+
+        {/* Question block — elevated, with decorative open quote */}
+        {payload.question && (
+          <aside
+            className={`relative mt-5 rounded-xl border ${tone.cardBorder} bg-gray-50/80 px-4 py-3 pl-8 sm:px-5 sm:pl-10`}
+          >
+            <span
+              aria-hidden
+              className={`pointer-events-none absolute left-2 top-0 select-none font-[var(--font-playfair)] text-[42px] leading-none ${tone.quoteGlyph} sm:left-3 sm:text-[56px]`}
+            >
+              &ldquo;
+            </span>
+            <p className="font-[var(--font-cinzel)] text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-400">
+              Question
+            </p>
+            <p className="mt-0.5 font-[var(--font-cormorant)] text-[17px] italic leading-snug text-gray-700 sm:text-[19px]">
+              {payload.question}
+            </p>
+          </aside>
+        )}
+
+        {/* Question answered */}
+        {payload.questionAnswered && (
+          <aside className="mt-3 rounded-lg border border-gray-200 bg-gray-50/60 px-4 py-2.5">
+            <p className="font-[var(--font-cinzel)] text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-400">
+              Answering
+            </p>
+            <p className="mt-0.5 text-sm text-gray-700">
+              {payload.questionAnswered}
+            </p>
+          </aside>
+        )}
+
+        {/* Violations */}
+        {turn.violations.length > 0 && (
+          <div className="mt-3 space-y-1">
+            {turn.violations.map((v, i) => (
+              <p
+                key={i}
+                className="flex items-center gap-1.5 text-xs text-red-500/80"
+              >
+                <span aria-hidden>⚠</span>
+                {v}
+              </p>
+            ))}
+          </div>
+        )}
       </div>
-    </motion.div>
+    </article>
   );
 }

--- a/frontend/src/components/StageProgressTracker.tsx
+++ b/frontend/src/components/StageProgressTracker.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 import type { StageConfig, Speaker } from "@/lib/api";
 import { formatStageLabel } from "@/lib/format-stage-label";
 
@@ -43,35 +42,24 @@ export default function StageProgressTracker({
     : (completedCount / totalStages) * 100;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: -5 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: 0.1 }}
-      className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5"
-    >
-      {/* Progress bar */}
+    <div className="enter-down rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:p-5">
+      {/* Progress bar — width animates via CSS transition (transform would be
+          nicer but width is clearer visually and this only animates on change). */}
       <div className="relative mb-4">
         <div className="h-2 w-full overflow-hidden rounded-full bg-gray-100">
-          <motion.div
-            initial={{ width: 0 }}
-            animate={{ width: `${progressPercent}%` }}
-            transition={{ duration: 0.8, ease: "easeOut" }}
-            className="h-full rounded-full bg-gradient-to-r from-blue-500 via-purple-500 to-emerald-500"
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-blue-500 via-purple-500 to-emerald-500 transition-[width] duration-700 ease-out"
+            style={{ width: `${progressPercent}%` }}
           />
         </div>
-        {/* Completion text */}
         <div className="mt-2 flex items-center justify-between">
           <span className="text-[10px] font-medium text-gray-400">
             {completedCount}/{totalStages} stages
           </span>
           {isCompleted && (
-            <motion.span
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-bold text-emerald-600"
-            >
+            <span className="enter-spring-pop rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-bold text-emerald-600">
               Complete
-            </motion.span>
+            </span>
           )}
         </div>
       </div>
@@ -90,20 +78,19 @@ export default function StageProgressTracker({
               onMouseEnter={() => setHoveredIndex(idx)}
               onMouseLeave={() => setHoveredIndex(null)}
             >
-              {/* Connector line */}
               {idx > 0 && (
                 <div
                   className={`absolute right-1/2 top-[14px] h-0.5 w-full -translate-y-1/2 ${
-                    isComplete ? "bg-gradient-to-r from-blue-300 to-purple-300" : "bg-gray-100"
+                    isComplete
+                      ? "bg-gradient-to-r from-blue-300 to-purple-300"
+                      : "bg-gray-100"
                   }`}
                   style={{ left: "-50%" }}
                 />
               )}
 
-              {/* Dot/Tick */}
-              <motion.div
-                whileHover={{ scale: 1.2 }}
-                className={`relative z-10 flex h-7 w-7 cursor-pointer items-center justify-center rounded-full text-[10px] font-bold transition-all sm:h-8 sm:w-8 sm:text-xs ${
+              <div
+                className={`relative z-10 flex h-7 w-7 cursor-pointer items-center justify-center rounded-full text-[10px] font-bold transition-transform duration-150 hover:scale-110 sm:h-8 sm:w-8 sm:text-xs ${
                   isComplete
                     ? `bg-gradient-to-br ${speakerColors[stage.speaker]} text-white shadow-md`
                     : isCurrent
@@ -131,16 +118,9 @@ export default function StageProgressTracker({
 
                 {/* Pulsing ring for current stage */}
                 {isCurrent && (
-                  <motion.div
-                    className="absolute inset-0 rounded-full border-2 border-blue-400"
-                    animate={{
-                      scale: [1, 1.3, 1],
-                      opacity: [0.6, 0, 0.6],
-                    }}
-                    transition={{ duration: 2, repeat: Infinity }}
-                  />
+                  <span className="stage-pulse absolute inset-0 rounded-full border-2 border-blue-400" />
                 )}
-              </motion.div>
+              </div>
 
               {/* Label (desktop only) */}
               <span
@@ -151,35 +131,32 @@ export default function StageProgressTracker({
                 {humanizeLabel(stage.label).split(" ").slice(0, 2).join("\n")}
               </span>
 
-              {/* Hover tooltip */}
-              <AnimatePresence>
-                {isHovered && (
-                  <motion.div
-                    initial={{ opacity: 0, y: 5, scale: 0.95 }}
-                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                    exit={{ opacity: 0, y: 5, scale: 0.95 }}
-                    transition={{ duration: 0.15 }}
-                    className="absolute -top-16 z-20 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-lg"
-                  >
-                    <p className="text-xs font-bold text-gray-900">{humanizeLabel(stage.label)}</p>
-                    <p className={`text-[10px] ${speakerTextColors[stage.speaker]}`}>
-                      {stage.speaker === "A"
-                        ? personaAName
-                        : stage.speaker === "B"
-                        ? personaBName
-                        : stage.speaker}
-                      {stage.maxWords ? ` - ${stage.maxWords} max words` : ""}
-                    </p>
-                    <div className="absolute left-1/2 top-full -translate-x-1/2">
-                      <div className="h-0 w-0 border-x-4 border-t-4 border-x-transparent border-t-white" />
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+              {/* Hover tooltip — CSS opacity transition. Kept always mounted so
+                  enter/exit are free. */}
+              <div
+                className={`pointer-events-none absolute -top-16 z-20 whitespace-nowrap rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-lg transition-opacity duration-150 ${
+                  isHovered ? "opacity-100" : "opacity-0"
+                }`}
+              >
+                <p className="text-xs font-bold text-gray-900">
+                  {humanizeLabel(stage.label)}
+                </p>
+                <p className={`text-[10px] ${speakerTextColors[stage.speaker]}`}>
+                  {stage.speaker === "A"
+                    ? personaAName
+                    : stage.speaker === "B"
+                    ? personaBName
+                    : stage.speaker}
+                  {stage.maxWords ? ` - ${stage.maxWords} max words` : ""}
+                </p>
+                <div className="absolute left-1/2 top-full -translate-x-1/2">
+                  <div className="h-0 w-0 border-x-4 border-t-4 border-x-transparent border-t-white" />
+                </div>
+              </div>
             </div>
           );
         })}
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/frontend/src/lib/use-animated-presence.ts
+++ b/frontend/src/lib/use-animated-presence.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Replacement for framer-motion's AnimatePresence. Keeps an element mounted
+ * briefly after `isPresent` flips to false so a CSS exit animation can play,
+ * then unmounts.
+ *
+ * Returns `[shouldRender, isExiting]`:
+ *   - shouldRender: whether the JSX should be rendered at all
+ *   - isExiting: true once `isPresent` flipped to false, false while active
+ *
+ * Apply an enter class based on shouldRender && !isExiting, and an exit class
+ * based on isExiting. Match the `exitDurationMs` to the CSS animation length.
+ */
+export function useAnimatedPresence(
+  isPresent: boolean,
+  exitDurationMs = 180,
+): [boolean, boolean] {
+  const [shouldRender, setShouldRender] = useState(isPresent);
+  const [isExiting, setIsExiting] = useState(false);
+
+  useEffect(() => {
+    if (isPresent) {
+      setShouldRender(true);
+      setIsExiting(false);
+      return;
+    }
+    // Flipped to absent — play exit then unmount.
+    if (shouldRender) {
+      setIsExiting(true);
+      const t = setTimeout(() => {
+        setShouldRender(false);
+        setIsExiting(false);
+      }, exitDurationMs);
+      return () => clearTimeout(t);
+    }
+  }, [isPresent, exitDurationMs, shouldRender]);
+
+  return [shouldRender, isExiting];
+}


### PR DESCRIPTION
User feedback: the live streaming card looks great, then gets replaced by a plainer version when it saves. Bad.

Fix: both cards now share the same visual language. Full-width article card, left-accent bar in speaker tone, avatar + name + role badge header (Live chip for streaming, For/Against/Mod/Judge for saved), Playfair drop-cap first letter in tone color, Cormorant italic + decorative open-quote for question blocks.

Also: StageProgressTracker stripped of framer-motion (first file in the aggressive FM rip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)