### PR TITLE
Rename target RG: debater-rg → debater-prod-rg

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           DB_URL=$(az containerapp secret show \
             --name debater-api \
-            --resource-group debater-rg \
+            --resource-group debater-prod-rg \
             --secret-name database-url \
             --query value -o tsv)
           echo "::add-mask::$DB_URL"
@@ -65,5 +65,5 @@ jobs:
         run: |
           az containerapp update \
             --name debater-api \
-            --resource-group debater-rg \
+            --resource-group debater-prod-rg \
             --image debateracr.azurecr.io/debater-api:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Brings `debater-rg` onto the project's `<project>-<env>-rg` naming convention
- Updates the two hardcoded RG references in `deploy-backend.yml` (`az containerapp secret show` and `az containerapp update`)

## Why now
RG names should be consistent: `fpto-prod-rg`, `apply-prod-rg`, etc. all use the `-prod-rg` suffix. `debater-rg` was the odd one out.

## Sequencing
**Hold this PR — do not merge** until the Azure resource move (`debateracr`, `debater-env`, `debater-api`, `debater-frontend`, plus the workspace) from `debater-rg` to `debater-prod-rg` is complete. Merging while resources are still in the old RG will cause the next backend deploy to fail on the `az containerapp secret show` step.

The service principal that backs `AZURE_CREDENTIALS` has already been granted `Contributor` on `debater-prod-rg`.

## Test plan
- [ ] Confirm Azure RG move complete: `az resource list --resource-group debater-prod-rg` shows the container app + ACR + env
- [ ] Confirm SP role assignment: `az role assignment list --resource-group debater-prod-rg` includes the deploy SP
- [ ] Merge this PR; verify a backend change (push to `backend/**` on main) triggers a clean deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)